### PR TITLE
Simplify the logo text customization

### DIFF
--- a/.github/workflows/mikrotik_patch_6.yml
+++ b/.github/workflows/mikrotik_patch_6.yml
@@ -27,6 +27,7 @@ env:
   CUSTOM_RENEW_URL: ${{ secrets.CUSTOM_RENEW_URL }}
   MIKRO_CLOUD_URL: ${{ secrets.MIKRO_CLOUD_URL }}
   CUSTOM_CLOUD_URL: ${{ secrets.CUSTOM_CLOUD_URL }}
+  CUSTOM_LOGO_TEXT: ${{ secrets.CUSTOM_LOGO_TEXT }}
 
 jobs:
   Set_BuildTime:

--- a/.github/workflows/mikrotik_patch_7.yml
+++ b/.github/workflows/mikrotik_patch_7.yml
@@ -26,6 +26,7 @@ env:
   CUSTOM_RENEW_URL: ${{ secrets.CUSTOM_RENEW_URL }}
   MIKRO_CLOUD_URL: ${{ secrets.MIKRO_CLOUD_URL }}
   CUSTOM_CLOUD_URL: ${{ secrets.CUSTOM_CLOUD_URL }}
+  CUSTOM_LOGO_TEXT: ${{ secrets.CUSTOM_LOGO_TEXT }}
 
 jobs:
   Set_BuildTime:

--- a/patch.py
+++ b/patch.py
@@ -303,9 +303,10 @@ def patch_npk_package(package,key_dict):
         print(f"extract {squashfs_file} ...")
         run_shell_command(f"unsquashfs -d {extract_dir} {squashfs_file}")
         patch_squashfs(extract_dir,key_dict)
-        logo = os.path.join(extract_dir,"nova/lib/console/logo.txt")
-        run_shell_command(f"sudo sed -i '1d' {logo}") 
-        run_shell_command(f"sudo sed -i '8s#.*#  elseif@live.cn     https://github.com/elseif/MikroTikPatch#' {logo}")
+        if ('CUSTOM_LOGO_TEXT' in os.environ) and (len(os.environ['CUSTOM_LOGO_TEXT']) > 0):
+            logo = os.path.join(extract_dir,"nova/lib/console/logo.txt")
+            run_shell_command(f"sudo sed -i '1d' {logo}")
+            run_shell_command(f"sudo sed -i '8s#.*#{os.environ['CUSTOM_LOGO_TEXT']}#' {logo}")
         print(f"pack {extract_dir} ...")
         run_shell_command(f"rm -f {squashfs_file}")
         run_shell_command(f"mksquashfs {extract_dir} {squashfs_file} -quiet -comp xz -no-xattrs -b 256k")


### PR DESCRIPTION
I've noticed that many forks change the logo text or even eliminate this alteration at all. But I understand you would like to keep your e-mail and the repository address to distinguish the patched software versions from the original ones.

This PR simplifies the logo text customization. Once merged, you would have to add `CUSTOM_LOGO_TEXT` with `  elseif@live.cn     https://github.com/elseif/MikroTikPatch` value to the list of secrets. Anyone using your repository for one's own purposes may do the same if needed. No logo text customization is done unless `CUSTOM_LOGO_TEXT` has any non-empty value.