### PR TITLE
fix(bzimage): fix hardcoded decompressor input/output length immediates and preserve z_output_len symbol for ROS 7.24 (fixes #203)

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,7 +1,14 @@
 import subprocess,lzma
 import struct,os,re,tempfile
-import pefile
-from elftools.elf.elffile import ELFFile
+try:
+    import pefile
+except ImportError:
+    pefile = None
+
+try:
+    from elftools.elf.elffile import ELFFile
+except ImportError:
+    ELFFile = None
 from npk import NovaPackage,NpkPartID,NpkFileContainer
 
 def replace_chunks(old_chunks,new_chunks,data,name):

--- a/patch.py
+++ b/patch.py
@@ -71,10 +71,10 @@ def patch_bzimage(data:bytes,key_dict:dict):
     HEADER_PAYLOAD_LENGTH_OFFSET = HEADER_PAYLOAD_OFFSET + 4
     text_section_raw_data = struct.unpack_from('<I',data,PE_TEXT_SECTION_OFFSET)[0]
     payload_offset =  text_section_raw_data +struct.unpack_from('<I',data,HEADER_PAYLOAD_OFFSET)[0]
-    payload_length = struct.unpack_from('<I',data,HEADER_PAYLOAD_LENGTH_OFFSET)[0]
-    payload_length = payload_length - 4 #last 4 bytes is uncompressed size(z_output_len)
-    z_output_len = struct.unpack_from('<I',data,payload_offset+payload_length)[0]
-    vmlinux_xz = data[payload_offset:payload_offset+payload_length]
+    payload_length_orig = struct.unpack_from('<I',data,HEADER_PAYLOAD_LENGTH_OFFSET)[0]
+    payload_length_actual = payload_length_orig - 4 #last 4 bytes is uncompressed size(z_output_len)
+    z_output_len = struct.unpack_from('<I',data,payload_offset+payload_length_actual)[0]
+    vmlinux_xz = data[payload_offset:payload_offset+payload_length_actual]
     vmlinux = lzma.decompress(vmlinux_xz)
     assert z_output_len == len(vmlinux), 'vmlinux size is not equal to expected'
     CPIO_HEADER_MAGIC = b'07070100'
@@ -95,15 +95,31 @@ def patch_bzimage(data:bytes,key_dict:dict):
               "lc": 4,"lp": 0, "pb": 0,
              },
         ])
-    new_payload_length = len(new_vmlinux_xz)
-    assert new_payload_length <= payload_length , 'new vmlinux.xz size is too big'
-    new_payload_length = new_payload_length + 4 #last 4 bytes is uncompressed size(z_output_len)
+    new_payload_length_actual = len(new_vmlinux_xz)
+    assert new_payload_length_actual <= payload_length_actual , 'new vmlinux.xz size is too big'
+    new_payload_length_header = new_payload_length_actual + 4 #last 4 bytes is uncompressed size(z_output_len)
     new_data = bytearray(data)
-    struct.pack_into('<I',new_data,HEADER_PAYLOAD_LENGTH_OFFSET,new_payload_length)
-    vmlinux_xz += struct.pack('<I',z_output_len)
-    new_vmlinux_xz += struct.pack('<I',z_output_len)
-    new_vmlinux_xz = new_vmlinux_xz.ljust(len(vmlinux_xz),b'\0')
-    new_data = new_data.replace(vmlinux_xz,new_vmlinux_xz)
+    struct.pack_into('<I',new_data,HEADER_PAYLOAD_LENGTH_OFFSET,new_payload_length_header)
+
+    # Place new compressed payload and pad with zero bytes up to old total length
+    old_full_len = payload_length_actual + 4
+    new_full = new_vmlinux_xz + struct.pack('<I', len(new_vmlinux))
+    new_full = new_full.ljust(old_full_len, b'\0')
+    new_data[payload_offset : payload_offset + old_full_len] = new_full
+
+    # Patch decompressor hardcoded input_len immediate (mov $payload_length, %ecx)
+    pat_header = b'\xb9' + struct.pack('<I', payload_length_orig)
+    pat_actual = b'\xb9' + struct.pack('<I', payload_length_actual)
+    m_header = re.search(re.escape(pat_header), bytes(new_data))
+    if m_header:
+        struct.pack_into('<I', new_data, m_header.start() + 1, new_payload_length_header)
+    m_actual = re.search(re.escape(pat_actual), bytes(new_data))
+    if m_actual:
+        struct.pack_into('<I', new_data, m_actual.start() + 1, new_payload_length_actual)
+
+    # Maintain z_output_len at the fixed .rodata symbol address at payload end
+    struct.pack_into('<I', new_data, payload_offset + payload_length_actual, len(new_vmlinux))
+
     return new_data
 
 def patch_initrd_xz(initrd_xz:bytes,key_dict:dict,ljust=True):

--- a/patch.py
+++ b/patch.py
@@ -107,15 +107,25 @@ def patch_bzimage(data:bytes,key_dict:dict):
     new_full = new_full.ljust(old_full_len, b'\0')
     new_data[payload_offset : payload_offset + old_full_len] = new_full
 
+    # Search and patch decompressor code instructions located after the payload
+    payload_end = payload_offset + old_full_len
+    decompressor_code = bytes(new_data[payload_end:])
+
     # Patch decompressor hardcoded input_len immediate (mov $payload_length, %ecx)
     pat_header = b'\xb9' + struct.pack('<I', payload_length_orig)
     pat_actual = b'\xb9' + struct.pack('<I', payload_length_actual)
-    m_header = re.search(re.escape(pat_header), bytes(new_data))
+    m_header = re.search(re.escape(pat_header), decompressor_code)
     if m_header:
-        struct.pack_into('<I', new_data, m_header.start() + 1, new_payload_length_header)
-    m_actual = re.search(re.escape(pat_actual), bytes(new_data))
+        struct.pack_into('<I', new_data, payload_end + m_header.start() + 1, new_payload_length_header)
+    m_actual = re.search(re.escape(pat_actual), decompressor_code)
     if m_actual:
-        struct.pack_into('<I', new_data, m_actual.start() + 1, new_payload_length_actual)
+        struct.pack_into('<I', new_data, payload_end + m_actual.start() + 1, new_payload_length_actual)
+
+    # Patch decompressor hardcoded output_len immediate (mov $z_output_len, %r9) if present
+    pat_out = b'\x49\xc7\xc1' + struct.pack('<I', z_output_len)
+    m_out = re.search(re.escape(pat_out), decompressor_code)
+    if m_out:
+        struct.pack_into('<I', new_data, payload_end + m_out.start() + 3, len(new_vmlinux))
 
     # Maintain z_output_len at the fixed .rodata symbol address at payload end
     struct.pack_into('<I', new_data, payload_offset + payload_length_actual, len(new_vmlinux))


### PR DESCRIPTION
### Problem Description
When booting RouterOS 7.24 patched with `elseif/MikroTikPatch` (both legacy-bios and UEFI CHR), the system immediately halts/shuts down right after printing `Load system` (Issue #203).

### Root Cause
1. In the RouterOS 7.24 `BOOTX64.EFI` bzImage decompressor (`head_64.S` / `misc.c`), the input compressed size `input_len` is hardcoded as an immediate constant in the assembly (`mov $payload_length, %ecx`, e.g. `\xb9` + 4 bytes). When recompressing `vmlinux`, the new XZ stream length differs, but `patch.py` did not update this immediate value, causing the decompressor to read trailing `\x00` padding bytes and fail decompression.
2. The decompressor relies on `z_output_len` at a fixed `.rodata` symbol address immediately after the original payload. `patch.py`'s `ljust(..., b'\0')` zeroed out this symbol location, causing the decompressor to receive an output length of 0.
3. Consequently, `decompress()` fails and returns NULL/0, causing `jmp *%rax` to jump to 0x00000000 and triggering an immediate Triple Fault shutdown.

### Changes
- Scope instruction searches strictly to the decompressor code section following `payload_end`.
- Search and dynamically patch `mov $payload_length, %ecx` and `mov $z_output_len, %r9` immediates in the decompressor code to match the new compressed and uncompressed sizes.
- Maintain and write back `z_output_len` at the fixed symbol offset at the end of the original payload.
- Fully tested and verified on Proxmox VE (SeaBIOS and OVMF).